### PR TITLE
Fix error variable already exist in trait

### DIFF
--- a/src/Routing/SitemapLoader.php
+++ b/src/Routing/SitemapLoader.php
@@ -19,12 +19,7 @@ use Symfony\Component\Routing\RouteCollection;
 class SitemapLoader extends Loader implements ContainerAwareInterface
 {
     use ContainerAwareTrait;
-
-    /**
-     * @var ContainerInterface
-     */
-    protected $container;
-
+    
     /**
      * @var bool
      */


### PR DESCRIPTION
Fix error :   [Symfony\Component\Debug\Exception\ContextErrorException]                                                                                                              
Runtime Notice: SitemapPlugin\Routing\SitemapLoader and Symfony\Component\DependencyInjection\ContainerAwareTrait define the same property ($container) in the composition of SitemapPlugin\Routing\SitemapLoader. This might be incompatible, to improve maintainability consider using accessor methods in traits instead. Class was composed