### PR TITLE
Fix duplicate results in static content sitemap (fixes #39)

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -73,7 +73,7 @@ final class Configuration implements ConfigurationInterface
                             ->end()
                             ->arrayNode('locales')
                                 ->prototype('scalar')
-                                ->info('Define which locales to add. If empty, it uses the default locale context supplied')
+                                ->info('Define which locales to add. If empty, it uses the default locales for channel context supplied')
                             ->end()
                         ->end()
                     ->end()

--- a/tests/Application/app/config/config.yml
+++ b/tests/Application/app/config/config.yml
@@ -15,6 +15,7 @@ imports:
 sitemap:
     static_routes:
         - { route: sylius_shop_order_show, parameters: { tokenValue: fooToken } }
+        - { route: sylius_shop_login, locales: [nl_NL, en_US] }
 
 framework:
     translator: { fallbacks: ["%locale%"] }

--- a/tests/Responses/Expected/show_sitemap_all.xml
+++ b/tests/Responses/Expected/show_sitemap_all.xml
@@ -53,4 +53,18 @@
     <changefreq>weekly</changefreq>
     <priority>0.3</priority>
   </url>
+  <url>
+    <loc>http://localhost/en_US/login</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="http://localhost/en_US/login"/>
+    <xhtml:link rel="alternate" hreflang="nl" href="http://localhost/nl_NL/login"/>
+    <changefreq>weekly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>http://localhost/nl_NL/login</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="http://localhost/en_US/login"/>
+    <xhtml:link rel="alternate" hreflang="nl" href="http://localhost/nl_NL/login"/>
+    <changefreq>weekly</changefreq>
+    <priority>0.3</priority>
+  </url>
 </urlset>

--- a/tests/Responses/Expected/show_sitemap_all_relative.xml
+++ b/tests/Responses/Expected/show_sitemap_all_relative.xml
@@ -53,4 +53,18 @@
     <changefreq>weekly</changefreq>
     <priority>0.3</priority>
   </url>
+  <url>
+    <loc>/en_US/login</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="/en_US/login"/>
+    <xhtml:link rel="alternate" hreflang="nl" href="/nl_NL/login"/>
+    <changefreq>weekly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>/nl_NL/login</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="/en_US/login"/>
+    <xhtml:link rel="alternate" hreflang="nl" href="/nl_NL/login"/>
+    <changefreq>weekly</changefreq>
+    <priority>0.3</priority>
+  </url>
 </urlset>

--- a/tests/Responses/Expected/show_sitemap_static.xml
+++ b/tests/Responses/Expected/show_sitemap_static.xml
@@ -42,4 +42,18 @@
     <changefreq>weekly</changefreq>
     <priority>0.3</priority>
   </url>
+  <url>
+    <loc>http://localhost/en_US/login</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="http://localhost/en_US/login"/>
+    <xhtml:link rel="alternate" hreflang="nl" href="http://localhost/nl_NL/login"/>
+    <changefreq>weekly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>http://localhost/nl_NL/login</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="http://localhost/en_US/login"/>
+    <xhtml:link rel="alternate" hreflang="nl" href="http://localhost/nl_NL/login"/>
+    <changefreq>weekly</changefreq>
+    <priority>0.3</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
Solves issue reported in #39 where routing became duplicate due to not filtering the default locale from the alternative locales.