### PR TITLE
Fixing an exception message

### DIFF
--- a/src/Routing/SitemapLoader.php
+++ b/src/Routing/SitemapLoader.php
@@ -47,7 +47,7 @@ class SitemapLoader extends Loader implements ContainerAwareInterface
     public function load($resource, $type = null): RouteCollection
     {
         if (true === $this->loaded) {
-            throw new \RuntimeException('Do not add the "extra" loader twice');
+            throw new \RuntimeException('Do not add the "sitemap" loader twice');
         }
 
         $routes = new RouteCollection();


### PR DESCRIPTION
When the loader is inadvertently loaded twice, the exception message presented has a typo. I'm assuming this originated from [here](https://symfony.com/doc/current/routing/custom_route_loader.html#creating-a-custom-loader)