### PR TITLE
WIP: Split big sitemaps & generate proper index (closes #79, #106)

### DIFF
--- a/src/Builder/SitemapIndexBuilder.php
+++ b/src/Builder/SitemapIndexBuilder.php
@@ -20,6 +20,9 @@ final class SitemapIndexBuilder implements SitemapIndexBuilderInterface
     /** @var array */
     private $indexProviders = [];
 
+    /** @var array */
+    private $paths = [];
+
     public function __construct(SitemapIndexFactoryInterface $sitemapIndexFactory)
     {
         $this->sitemapIndexFactory = $sitemapIndexFactory;
@@ -44,6 +47,18 @@ final class SitemapIndexBuilder implements SitemapIndexBuilderInterface
     /**
      * {@inheritdoc}
      */
+    public function addPath(UrlProviderInterface $provider, string $path): void
+    {
+        if (!array_key_exists($provider->getName(), $this->paths)) {
+            $this->paths[$provider->getName()] = [];
+        }
+
+        $this->paths[$provider->getName()][] = $path;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function build(): SitemapInterface
     {
         $sitemap = $this->sitemapIndexFactory->createNew();
@@ -53,7 +68,7 @@ final class SitemapIndexBuilder implements SitemapIndexBuilderInterface
         foreach ($this->indexProviders as $indexProvider) {
             /** @var UrlProviderInterface $provider */
             foreach ($this->providers as $provider) {
-                $indexProvider->addProvider($provider);
+                $indexProvider->addProvider($provider, $this->paths[$provider->getName()]);
             }
 
             $urls[] = $indexProvider->generate();

--- a/src/Controller/SitemapController.php
+++ b/src/Controller/SitemapController.php
@@ -22,9 +22,9 @@ final class SitemapController extends AbstractController
         parent::__construct($reader);
     }
 
-    public function showAction(string $name): Response
+    public function showAction(string $name, int $index): Response
     {
-        $path = \sprintf('%s/%s', $this->channelContext->getChannel()->getCode(), \sprintf('%s.xml', $name));
+        $path = \sprintf('%s/%s', $this->channelContext->getChannel()->getCode(), \sprintf('%s_%d.xml', $name, $index));
 
         return $this->createResponse($path);
     }

--- a/src/Provider/IndexUrlProvider.php
+++ b/src/Provider/IndexUrlProvider.php
@@ -21,6 +21,9 @@ final class IndexUrlProvider implements IndexUrlProviderInterface
     /** @var array */
     private $urls = [];
 
+    /** @var array */
+    private $paths = [];
+
     public function __construct(
         RouterInterface $router,
         IndexUrlFactoryInterface $sitemapIndexUrlFactory
@@ -29,17 +32,24 @@ final class IndexUrlProvider implements IndexUrlProviderInterface
         $this->sitemapIndexUrlFactory = $sitemapIndexUrlFactory;
     }
 
-    public function addProvider(UrlProviderInterface $provider): void
+    public function addProvider(UrlProviderInterface $provider, array $paths = []): void
     {
         $this->providers[] = $provider;
+        $this->paths[$provider->getName()] = $paths;
     }
 
     public function generate(): iterable
     {
         foreach ($this->providers as $provider) {
-            $location = $this->router->generate('sylius_sitemap_' . $provider->getName());
+            $pathCount = count($this->paths[$provider->getName()]);
 
-            $this->urls[] = $this->sitemapIndexUrlFactory->createNew($location);
+            for ($i = 0; $i < $pathCount; $i++) {
+                $params = ['index' => $i];
+
+                $location = $this->router->generate('sylius_sitemap_'.$provider->getName(), $params);
+
+                $this->urls[] = $this->sitemapIndexUrlFactory->createNew($location);
+            }
         }
 
         return $this->urls;

--- a/src/Provider/IndexUrlProviderInterface.php
+++ b/src/Provider/IndexUrlProviderInterface.php
@@ -11,5 +11,5 @@ interface IndexUrlProviderInterface
      */
     public function generate(): iterable;
 
-    public function addProvider(UrlProviderInterface $provider): void;
+    public function addProvider(UrlProviderInterface $provider, array $paths = []): void;
 }

--- a/src/Renderer/SitemapRenderer.php
+++ b/src/Renderer/SitemapRenderer.php
@@ -19,8 +19,19 @@ final class SitemapRenderer implements SitemapRendererInterface
     /**
      * {@inheritdoc}
      */
-    public function render(SitemapInterface $sitemap): string
+    public function render(SitemapInterface $sitemap, ?int $limit = null): iterable
     {
-        return $this->adapter->render($sitemap);
+        $urls = $sitemap->getUrls();
+        $total = count($urls);
+
+        if (null === $limit || $limit < 0) {
+            $limit = $total;
+        }
+
+        foreach(array_chunk($urls, $limit) as $slice) {
+            $sitemap->setUrls($slice);
+
+            yield $this->adapter->render($sitemap);
+        }
     }
 }

--- a/src/Renderer/SitemapRendererInterface.php
+++ b/src/Renderer/SitemapRendererInterface.php
@@ -8,5 +8,9 @@ use SitemapPlugin\Model\SitemapInterface;
 
 interface SitemapRendererInterface
 {
-    public function render(SitemapInterface $sitemap): string;
+
+    /**
+     * @return string[]
+     */
+    public function render(SitemapInterface $sitemap, ?int $limit = null): iterable;
 }

--- a/src/Routing/SitemapLoader.php
+++ b/src/Routing/SitemapLoader.php
@@ -34,7 +34,7 @@ final class SitemapLoader extends Loader implements ContainerAwareInterface
     public function load($resource, $type = null): RouteCollection
     {
         $routes = new RouteCollection();
-        
+
         if (true === $this->loaded) {
             return $routes;
         }
@@ -50,12 +50,14 @@ final class SitemapLoader extends Loader implements ContainerAwareInterface
             $routes->add(
                 $name,
                 new Route(
-                    '/sitemap/' . $provider->getName() . '.xml',
+                    '/sitemap/' . $provider->getName() . '/{index}.xml',
                     [
                         '_controller' => 'sylius.controller.sitemap:showAction',
                         'name' => $provider->getName(),
                     ],
-                    [],
+                    [
+                        'index' => '\d+',
+                    ],
                     [],
                     '',
                     [],


### PR DESCRIPTION
* Split big sitemaps based on a configurable limit (defaults to 50.000)
* Use the amount of files in generation of the URIs to these files (and use them in the index)