### PR TITLE
[Symfony 5+ and Sylius 1.9] Change parameter root_dir to project_dir

### DIFF
--- a/src/Resources/config/config.yaml
+++ b/src/Resources/config/config.yaml
@@ -5,7 +5,7 @@ sitemap:
 
 parameters:
     sylius.sitemap.filesystem: sylius_sitemap
-    sylius.sitemap.path: "%kernel.root_dir%/var/sitemap"
+    sylius.sitemap.path: "%kernel.project_dir%/var/sitemap"
 
 knp_gaufrette:
     adapters:


### PR DESCRIPTION
The parameter `%kernel.root_dir%` is not available on Symfony 5.0+. Use `%kernel.project_dir%` instead of `%kernel.root_dir%`.