### PR TITLE
Fix the redirect routing

### DIFF
--- a/src/Resources/config/routing.yml
+++ b/src/Resources/config/routing.yml
@@ -9,7 +9,7 @@ sylius_sitemap_index:
 sylius_sitemap_no_index:
     path: /sitemap.xml
     defaults:
-        _controller: FrameworkBundle:Redirect:redirect
+        _controller: 'Symfony\Bundle\FrameworkBundle\Controller\RedirectController:redirectAction'
         route: sylius_sitemap_index
         permanent: true
 

--- a/tests/Controller/SitemapIndexControllerApiTest.php
+++ b/tests/Controller/SitemapIndexControllerApiTest.php
@@ -37,6 +37,13 @@ final class SitemapIndexControllerApiTest extends AbstractTestController
         $this->generateSitemaps();
     }
 
+    public function testRedirectActionResponse()
+    {
+        $response = $this->getBufferedResponse('/sitemap.xml');
+
+        $this->assertResponseRedirects('http://localhost/sitemap_index.xml', 301);
+    }
+
     public function testShowActionResponse()
     {
         $response = $this->getBufferedResponse('/sitemap_index.xml');


### PR DESCRIPTION
This PR solves a configuration error with Sylius 1.9 and Symfony 5.2:

```
The controller for URI "/sitemap.xml" is not callable: Controller "FrameworkBundle:Redirect:redirect" does neither exist as service nor as class.
```