### PR TITLE
Use HTTPS instead of HTTP for sitemap schema

### DIFF
--- a/src/Resources/views/index.xml.twig
+++ b/src/Resources/views/index.xml.twig
@@ -1,7 +1,7 @@
 {% import '@SitemapPlugin/Macro/xml.html.twig' as xml_helper %}
 {% spaceless %}
 <?xml version="1.0" encoding="UTF-8"?>
-<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemapindex xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
     {%- for url in url_set -%}
         <sitemap>
             <loc>{{ absolute_url(url.location) }}</loc>

--- a/src/Resources/views/show.xml.twig
+++ b/src/Resources/views/show.xml.twig
@@ -2,7 +2,7 @@
 {% import '@SitemapPlugin/Macro/xml.html.twig' as xml_helper %}
 {% spaceless %}
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="https://www.google.com/schemas/sitemap-image/1.1" xmlns:xhtml="https://www.w3.org/1999/xhtml">
     {%- for url in url_set -%}
         <url>
             <loc>{{ absolute_url(url.location) }}</loc>


### PR DESCRIPTION
Hi! If your website is using HTTPS schema, the visualization of the sitemaps from a browser is not correctly rendered (it shows only the values as plain text like it was HTML). Using HTTPS for referring schemas will solve this problem.