### PR TITLE
Fix redundant url on multichannels sitemapindex

### DIFF
--- a/src/Builder/SitemapIndexBuilder.php
+++ b/src/Builder/SitemapIndexBuilder.php
@@ -29,9 +29,13 @@ final class SitemapIndexBuilder implements SitemapIndexBuilderInterface
         $this->providers[] = $provider;
     }
 
-    public function addIndexProvider(IndexUrlProviderInterface $provider): void
+    public function addIndexProvider(IndexUrlProviderInterface $indexProvider): void
     {
-        $this->indexProviders[] = $provider;
+        foreach ($this->providers as $provider) {
+            $indexProvider->addProvider($provider);
+        }
+
+        $this->indexProviders[] = $indexProvider;
     }
 
     public function build(): SitemapInterface
@@ -40,10 +44,6 @@ final class SitemapIndexBuilder implements SitemapIndexBuilderInterface
         $urls = [];
 
         foreach ($this->indexProviders as $indexProvider) {
-            foreach ($this->providers as $provider) {
-                $indexProvider->addProvider($provider);
-            }
-
             $urls[] = $indexProvider->generate();
         }
 

--- a/src/Builder/SitemapIndexBuilderInterface.php
+++ b/src/Builder/SitemapIndexBuilderInterface.php
@@ -9,7 +9,7 @@ use SitemapPlugin\Provider\IndexUrlProviderInterface;
 
 interface SitemapIndexBuilderInterface extends BuilderInterface
 {
-    public function addIndexProvider(IndexUrlProviderInterface $provider): void;
+    public function addIndexProvider(IndexUrlProviderInterface $indexProvider): void;
 
     public function build(): SitemapInterface;
 }

--- a/src/Provider/IndexUrlProvider.php
+++ b/src/Provider/IndexUrlProvider.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace SitemapPlugin\Provider;
 
 use SitemapPlugin\Factory\IndexUrlFactoryInterface;
-use SitemapPlugin\Model\IndexUrlInterface;
 use Symfony\Component\Routing\RouterInterface;
 
 final class IndexUrlProvider implements IndexUrlProviderInterface
@@ -16,9 +15,6 @@ final class IndexUrlProvider implements IndexUrlProviderInterface
     private RouterInterface $router;
 
     private IndexUrlFactoryInterface $sitemapIndexUrlFactory;
-
-    /** @var IndexUrlInterface[] */
-    private array $urls = [];
 
     public function __construct(
         RouterInterface $router,
@@ -35,12 +31,12 @@ final class IndexUrlProvider implements IndexUrlProviderInterface
 
     public function generate(): iterable
     {
+        $urls = [];
         foreach ($this->providers as $provider) {
             $location = $this->router->generate('sylius_sitemap_' . $provider->getName());
-
-            $this->urls[] = $this->sitemapIndexUrlFactory->createNew($location);
+            $urls[] = $this->sitemapIndexUrlFactory->createNew($location);
         }
 
-        return $this->urls;
+        return $urls;
     }
 }

--- a/tests/Controller/MultiChannelSitemapIndexControllerApiTest.php
+++ b/tests/Controller/MultiChannelSitemapIndexControllerApiTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\SitemapPlugin\Controller;
+
+final class MultiChannelSitemapIndexControllerApiTest extends XmlApiTestCase
+{
+    public function testShowActionResponse()
+    {
+        $this->loadFixturesFromFiles(['multi_channel.yaml']);
+        $this->generateSitemaps();
+
+        $response = $this->getBufferedResponse('http://localhost/sitemap_index.xml');
+        $this->assertResponse($response, 'show_sitemap_index');
+
+        $response = $this->getBufferedResponse('http://store.fr/sitemap_index.xml');
+        $this->assertResponse($response, 'show_second_sitemap_index');
+
+        $this->deleteSitemaps();
+    }
+}

--- a/tests/Responses/show_second_sitemap_index.xml
+++ b/tests/Responses/show_second_sitemap_index.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>http://store.fr/sitemap/products.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>http://store.fr/sitemap/taxons.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>http://store.fr/sitemap/static.xml</loc>
+  </sitemap>
+</sitemapindex>


### PR DESCRIPTION
On sitemap_index on multi-channels store, the first channel is OK, but the following have redundant sitemap providers URLs.
This is due to the build() function call in  GenerateSitemapCommand that is call several times in case of multi-channel.
The bug is due to this function that not only generate URLs, but also initialize indexProviders with providers.
I propose to move this initialization in compiler pass to be sure it's only performed once.
Moreover IndexUrlProvider also used url[] class attribute instead of local array (that created more duplicate)