### PR TITLE
Allow iterables in sitemap builders

### DIFF
--- a/src/Builder/SitemapBuilder.php
+++ b/src/Builder/SitemapBuilder.php
@@ -36,7 +36,7 @@ final class SitemapBuilder implements SitemapBuilderInterface
         $urls = [];
 
         $sitemap = $this->sitemapFactory->createNew();
-        $urls[] = $provider->generate($channel);
+        $urls[] = [...$provider->generate($channel)];
 
         $sitemap->setUrls(\array_merge(...$urls));
 

--- a/src/Builder/SitemapIndexBuilder.php
+++ b/src/Builder/SitemapIndexBuilder.php
@@ -44,7 +44,7 @@ final class SitemapIndexBuilder implements SitemapIndexBuilderInterface
         $urls = [];
 
         foreach ($this->indexProviders as $indexProvider) {
-            $urls[] = $indexProvider->generate();
+            $urls[] = [...$indexProvider->generate()];
         }
 
         $sitemap->setUrls(\array_merge(...$urls));


### PR DESCRIPTION
Fixes #258 

Since the minimum PHP version is 7.4 I used `[...$iterable]` instead of `iterator_to_array` as `iterator_to_array` does not accept all `iterable`s but only `Traversable|array`.

Also I'm not 100% familiar with PhpSpec, I feel like the test I wrote is a tad hacky, tell me if it's alright or if I should rewrite it