### PR TITLE
Allows Sylius >= 2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,8 @@ jobs:
             fail-fast: false
             matrix:
                 php: ["8.2", "8.3"]
-                symfony: ["^6.4", "^7.2"]
-                sylius: ["~2.0.0"]
+                symfony: ["^6.4", "^7.3"]
+                sylius: ["~2.0.0", "~2.1.0"]
                 node: ["18.x"]
                 mysql: ["8.0"]
                       

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: ["8.2", "8.3"]
-                symfony: ["^6.4", "^7.3"]
+                symfony: ["^6.4", "^7.2"]
                 sylius: ["~2.0.0", "~2.1.0"]
                 node: ["18.x"]
                 mysql: ["8.0"]

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": "^8.2",
         "league/flysystem-bundle": "^3.0",
-        "sylius/sylius": "~2.0.0"
+        "sylius/sylius": "^2.0"
     },
     "require-dev": {
         "lchrusciel/api-test-case": "^5.1",


### PR DESCRIPTION
This pull request updates the version constraint for the `sylius/sylius` package in `composer.json` to allow for more flexibility in compatible versions.

Dependency updates:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L13-R13): Changed the `sylius/sylius` version constraint from `~2.0.0` to `^2.0` to allow for any `2.x` version, including potential future minor and patch updates.

Related issue: #278 